### PR TITLE
feat(interbank): list incoming OTC negotiations (GET /bank/interbank/…

### DIFF
--- a/services/bank-service/internal/domain/interbank.go
+++ b/services/bank-service/internal/domain/interbank.go
@@ -393,6 +393,12 @@ type InterbankNegotiation struct {
 	UpdatedAt                 time.Time
 }
 
+// ListInterbankNegotiationsFilter — filter za listu OTC pregovora koje mi hostujemo.
+type ListInterbankNegotiationsFilter struct {
+	NegotiationRoutingNumber int64   // pregovori koje hostujemo (naš routing)
+	SellerID                 *string // opciono: samo gde je prodavac ovaj korisnik (CLIENT)
+}
+
 // InterbankOptionContract — opcioni ugovor po prihvaćenoj OTC ponudi.
 type InterbankOptionContract struct {
 	ID                       int64
@@ -438,6 +444,7 @@ type InterbankRepository interface {
 	CreateNegotiation(ctx context.Context, n *InterbankNegotiation) error
 	GetNegotiationByID(ctx context.Context, routingNumber int64, foreignID string) (*InterbankNegotiation, error)
 	UpdateNegotiation(ctx context.Context, n *InterbankNegotiation) error
+	ListNegotiations(ctx context.Context, filter ListInterbankNegotiationsFilter) ([]InterbankNegotiation, error)
 	ListPublicStocks(ctx context.Context) ([]PublicStock, error)
 
 	// Option contracts (interbank)

--- a/services/bank-service/internal/handler/interbank_payment_handler.go
+++ b/services/bank-service/internal/handler/interbank_payment_handler.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"banka-backend/services/bank-service/internal/domain"
 	"banka-backend/services/bank-service/internal/service"
@@ -80,7 +81,7 @@ func (h *InterbankPaymentHandler) authenticate(r *http.Request) (int64, string, 
 
 func (h *InterbankPaymentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	userID, _, err := h.authenticate(r)
+	userID, userType, err := h.authenticate(r)
 	if err != nil {
 		writeIBError(w, http.StatusUnauthorized, "unauthorized")
 		return
@@ -92,6 +93,8 @@ func (h *InterbankPaymentHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		h.handleCreatePayment(w, r, userID)
 	case path == "/bank/interbank/public-stocks" && r.Method == http.MethodGet:
 		h.handlePublicStocks(w, r)
+	case path == "/bank/interbank/negotiations" && r.Method == http.MethodGet:
+		h.handleListNegotiations(w, r, userID, userType)
 	case path == "/bank/interbank/negotiations" && r.Method == http.MethodPost:
 		h.handleCreateNegotiation(w, r, userID)
 	case path == "/bank/interbank/contracts" && r.Method == http.MethodGet:
@@ -262,6 +265,57 @@ func (h *InterbankPaymentHandler) handleCreateNegotiation(w http.ResponseWriter,
 		return
 	}
 	writeIBJSON(w, http.StatusOK, id)
+}
+
+// ─── GET /bank/interbank/negotiations (dolazne ponude koje mi hostujemo) ──────
+
+type negotiationListItemDTO struct {
+	NegotiationID  domain.ForeignBankId `json:"negotiationId"`
+	Ticker         string               `json:"ticker"`
+	Amount         int32                `json:"amount"`
+	PricePerUnit   domain.MonetaryValue `json:"pricePerUnit"`
+	Premium        domain.MonetaryValue `json:"premium"`
+	SettlementDate string               `json:"settlementDate"`
+	Buyer          domain.ForeignBankId `json:"buyer"`
+	Seller         domain.ForeignBankId `json:"seller"`
+	Status         string               `json:"status"`
+	IsOngoing      bool                 `json:"isOngoing"`
+	LastModifiedBy domain.ForeignBankId `json:"lastModifiedBy"`
+	MyTurn         bool                 `json:"myTurn"`
+}
+
+// handleListNegotiations vraća OTC pregovore koje smo mi banka prodavca (host).
+// CLIENT vidi samo pregovore gde je on prodavac; AGENT/SUPERVISOR vide sve.
+func (h *InterbankPaymentHandler) handleListNegotiations(w http.ResponseWriter, r *http.Request, userID int64, userType string) {
+	var sellerID *string
+	if userType == "CLIENT" {
+		s := strconv.FormatInt(userID, 10)
+		sellerID = &s
+	}
+	rows, err := h.otcSvc.ListNegotiations(r.Context(), sellerID)
+	if err != nil {
+		writeIBError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	out := make([]negotiationListItemDTO, 0, len(rows))
+	for i := range rows {
+		n := &rows[i]
+		out = append(out, negotiationListItemDTO{
+			NegotiationID:  domain.ForeignBankId{RoutingNumber: n.NegotiationRoutingNumber, ID: n.NegotiationForeignID},
+			Ticker:         n.StockTicker,
+			Amount:         n.Amount,
+			PricePerUnit:   domain.MonetaryValue{Currency: n.PriceCurrency, Amount: n.PriceAmount},
+			Premium:        domain.MonetaryValue{Currency: n.PremiumCurrency, Amount: n.PremiumAmount},
+			SettlementDate: n.SettlementDate.Format(time.RFC3339),
+			Buyer:          domain.ForeignBankId{RoutingNumber: n.BuyerRoutingNumber, ID: n.BuyerID},
+			Seller:         domain.ForeignBankId{RoutingNumber: n.SellerRoutingNumber, ID: n.SellerID},
+			Status:         n.Status,
+			IsOngoing:      n.IsOngoing,
+			LastModifiedBy: domain.ForeignBankId{RoutingNumber: n.LastModifiedRoutingNumber, ID: n.LastModifiedID},
+			MyTurn:         n.IsOngoing && n.LastModifiedRoutingNumber != h.ourRoutingNumber,
+		})
+	}
+	writeIBJSON(w, http.StatusOK, out)
 }
 
 func (h *InterbankPaymentHandler) handleNegotiationsSubpath(w http.ResponseWriter, r *http.Request, userID int64) {

--- a/services/bank-service/internal/repository/interbank_repository.go
+++ b/services/bank-service/internal/repository/interbank_repository.go
@@ -531,6 +531,23 @@ func (r *interbankRepository) UpdateNegotiation(ctx context.Context, n *domain.I
 	return r.db.WithContext(ctx).Save(mod).Error
 }
 
+func (r *interbankRepository) ListNegotiations(ctx context.Context, filter domain.ListInterbankNegotiationsFilter) ([]domain.InterbankNegotiation, error) {
+	q := r.db.WithContext(ctx).
+		Where("negotiation_routing_number = ?", filter.NegotiationRoutingNumber)
+	if filter.SellerID != nil {
+		q = q.Where("seller_routing_number = ? AND seller_id = ?", filter.NegotiationRoutingNumber, *filter.SellerID)
+	}
+	var models []interbankNegotiationModel
+	if err := q.Order("updated_at DESC").Find(&models).Error; err != nil {
+		return nil, err
+	}
+	out := make([]domain.InterbankNegotiation, 0, len(models))
+	for i := range models {
+		out = append(out, *negToDomain(&models[i]))
+	}
+	return out, nil
+}
+
 // ListPublicStocks agregira public_shares iz lokalnog portfolija po (listing, user)
 // — public_shares.quantity je već "javni režim" za OTC. Vraća listu po tickerima.
 func (r *interbankRepository) ListPublicStocks(ctx context.Context) ([]domain.PublicStock, error) {

--- a/services/bank-service/internal/service/interbank_otc_service.go
+++ b/services/bank-service/internal/service/interbank_otc_service.go
@@ -141,6 +141,15 @@ func (s *InterbankOTCService) GetNegotiation(ctx context.Context, routing int64,
 	}, nil
 }
 
+// ListNegotiations — vraća OTC pregovore koje mi hostujemo (naš routing).
+// Ako je sellerID != nil, filtrira na pregovore gde je prodavac taj korisnik (za CLIENT).
+func (s *InterbankOTCService) ListNegotiations(ctx context.Context, sellerID *string) ([]domain.InterbankNegotiation, error) {
+	return s.repo.ListNegotiations(ctx, domain.ListInterbankNegotiationsFilter{
+		NegotiationRoutingNumber: s.ourRoutingNumber,
+		SellerID:                 sellerID,
+	})
+}
+
 // CancelNegotiation — DELETE /negotiations/{routing}/{id}; postavlja IsOngoing=false.
 func (s *InterbankOTCService) CancelNegotiation(ctx context.Context, routing int64, id string) error {
 	n, err := s.repo.GetNegotiationByID(ctx, routing, id)

--- a/services/bank-service/internal/service/interbank_otc_service_test.go
+++ b/services/bank-service/internal/service/interbank_otc_service_test.go
@@ -82,6 +82,13 @@ func (m *mockInterbankRepo) GetNegotiationByID(ctx context.Context, rn int64, fi
 func (m *mockInterbankRepo) UpdateNegotiation(ctx context.Context, n *domain.InterbankNegotiation) error {
 	return m.Called(ctx, n).Error(0)
 }
+func (m *mockInterbankRepo) ListNegotiations(ctx context.Context, filter domain.ListInterbankNegotiationsFilter) ([]domain.InterbankNegotiation, error) {
+	args := m.Called(ctx, filter)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]domain.InterbankNegotiation), args.Error(1)
+}
 func (m *mockInterbankRepo) ListPublicStocks(ctx context.Context) ([]domain.PublicStock, error) {
 	args := m.Called(ctx)
 	if args.Get(0) == nil {
@@ -385,4 +392,43 @@ func TestInterbankOTC_CancelNegotiation_RepoError(t *testing.T) {
 
 	err := svc.CancelNegotiation(ctx, ourRouting, "x")
 	require.Error(t, err)
+}
+
+// ─── ListNegotiations ─────────────────────────────────────────────────────────
+
+func TestInterbankOTC_ListNegotiations_ClientFiltersBySeller(t *testing.T) {
+	repo := &mockInterbankRepo{}
+	ctx := context.Background()
+	svc := service.NewInterbankOTCService(repo, ourRouting)
+
+	sellerID := "4"
+	want := []domain.InterbankNegotiation{{
+		ID: 1, NegotiationRoutingNumber: ourRouting, NegotiationForeignID: "neg1",
+		StockTicker: "AAPL", Amount: 10, SellerRoutingNumber: ourRouting, SellerID: "4",
+		BuyerRoutingNumber: 222, BuyerID: "C-1", Status: "OPEN", IsOngoing: true,
+	}}
+	repo.On("ListNegotiations", ctx, domain.ListInterbankNegotiationsFilter{
+		NegotiationRoutingNumber: ourRouting, SellerID: &sellerID,
+	}).Return(want, nil)
+
+	got, err := svc.ListNegotiations(ctx, &sellerID)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "AAPL", got[0].StockTicker)
+	repo.AssertExpectations(t)
+}
+
+func TestInterbankOTC_ListNegotiations_EmployeeNoSellerFilter(t *testing.T) {
+	repo := &mockInterbankRepo{}
+	ctx := context.Background()
+	svc := service.NewInterbankOTCService(repo, ourRouting)
+
+	repo.On("ListNegotiations", ctx, domain.ListInterbankNegotiationsFilter{
+		NegotiationRoutingNumber: ourRouting, SellerID: nil,
+	}).Return([]domain.InterbankNegotiation{}, nil)
+
+	got, err := svc.ListNegotiations(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 0)
+	repo.AssertExpectations(t)
 }

--- a/services/bank-service/internal/service/local_transaction_executor_test.go
+++ b/services/bank-service/internal/service/local_transaction_executor_test.go
@@ -215,6 +215,13 @@ func (m *mockInterbankRepoForExecutor) GetNegotiationByID(ctx context.Context, r
 func (m *mockInterbankRepoForExecutor) UpdateNegotiation(ctx context.Context, n *domain.InterbankNegotiation) error {
 	return m.Called(ctx, n).Error(0)
 }
+func (m *mockInterbankRepoForExecutor) ListNegotiations(ctx context.Context, filter domain.ListInterbankNegotiationsFilter) ([]domain.InterbankNegotiation, error) {
+	args := m.Called(ctx, filter)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]domain.InterbankNegotiation), args.Error(1)
+}
 func (m *mockInterbankRepoForExecutor) ListPublicStocks(ctx context.Context) ([]domain.PublicStock, error) {
 	args := m.Called(ctx)
 	if args.Get(0) == nil {


### PR DESCRIPTION
…negotiations)

Seller bank can now see inbound OTC offers stored in interbank_negotiation. CLIENT sees own; AGENT/SUPERVISOR see all. Adds repo+service+handler ListNegotiations + DTO + role filter; service tests + mock stubs for the new interface method.